### PR TITLE
Produce even better DOT graphs

### DIFF
--- a/src/ops/base.rs
+++ b/src/ops/base.rs
@@ -65,4 +65,8 @@ impl NodeOp for Base {
     fn is_base(&self) -> bool {
         true
     }
+
+    fn description(&self) -> String {
+        "B".into()
+    }
 }

--- a/src/ops/gatedid.rs
+++ b/src/ops/gatedid.rs
@@ -73,6 +73,10 @@ impl NodeOp for GatedIdentity {
     fn resolve(&self, col: usize) -> Option<Vec<(flow::NodeIndex, usize)>> {
         Some(vec![(self.src, col)])
     }
+
+    fn description(&self) -> String {
+        "GatedIdentity".into()
+    }
 }
 
 #[cfg(test)]

--- a/src/ops/grouped/aggregate.rs
+++ b/src/ops/grouped/aggregate.rs
@@ -98,6 +98,16 @@ impl GroupedOperation for Aggregator {
             unreachable!();
         }
     }
+
+    fn description(&self) -> String {
+        let op_string = match self.op {
+            Aggregation::COUNT => "|*|".into(),
+            Aggregation::SUM => format!("𝛴({})", self.over),
+        };
+        let group_cols = self.group.iter().map(|g| g.to_string())
+            .collect::<Vec<_>>().join(", ");
+        format!("{} γ[{}]", op_string, group_cols)
+    }
 }
 
 #[cfg(test)]
@@ -142,6 +152,19 @@ mod tests {
         } else {
             ops::new("agg", &["x", "ys"], mat, c)
         }
+    }
+
+    #[test]
+    fn it_describes() {
+        let s = 0.into();
+
+        let c = ops::new("count", &["x", "z", "ys"], true,
+                         Aggregation::COUNT.over(s, 1, &[0, 2]));
+        assert_eq!(c.inner.description(), "|*| γ[0, 2]");
+
+        let c = ops::new("sum", &["x", "z", "ys"], true,
+                         Aggregation::SUM.over(s, 1, &[2, 0]));
+        assert_eq!(c.inner.description(), "𝛴(1) γ[2, 0]");
     }
 
     #[test]

--- a/src/ops/grouped/mod.rs
+++ b/src/ops/grouped/mod.rs
@@ -63,6 +63,8 @@ pub trait GroupedOperation: fmt::Debug {
     /// Given the given `current` value, and a number of changes for a group (`diffs`), compute the
     /// updated group value.
     fn apply(&self, current: &query::DataType, diffs: Vec<(Self::Diff, i64)>) -> query::DataType;
+
+    fn description(&self) -> String;
 }
 
 #[derive(Debug)]
@@ -368,5 +370,9 @@ impl<T: GroupedOperation> NodeOp for GroupedOperator<T> {
             return None;
         }
         Some(vec![(self.src, self.colfix[col])])
+    }
+
+    fn description(&self) -> String {
+        self.inner.description()
     }
 }

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -59,6 +59,10 @@ impl NodeOp for Identity {
     fn resolve(&self, col: usize) -> Option<Vec<(flow::NodeIndex, usize)>> {
         Some(vec![(self.src, col)])
     }
+
+    fn description(&self) -> String {
+        "≡".into()
+    }
 }
 
 #[cfg(test)]

--- a/src/ops/latest.rs
+++ b/src/ops/latest.rs
@@ -258,6 +258,12 @@ impl NodeOp for Latest {
     fn resolve(&self, col: usize) -> Option<Vec<(flow::NodeIndex, usize)>> {
         Some(vec![(self.src, col)])
     }
+
+    fn description(&self) -> String {
+        let key_cols = self.key.iter().map(|k| k.to_string())
+            .collect::<Vec<_>>().join(", ");
+        format!("⧖ γ[{}]", key_cols)
+    }
 }
 
 #[cfg(test)]
@@ -306,6 +312,12 @@ mod tests {
         } else {
             ops::new("latest", &["x", "y"], mat, l)
         }
+    }
+
+    #[test]
+    fn it_describes() {
+        let c = setup(vec![0, 2], false);
+        assert_eq!(c.inner.description(), "⧖ γ[2, 0]");
     }
 
     #[test]

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -150,6 +150,21 @@ pub trait NodeOp: Debug {
     fn is_base(&self) -> bool {
         false
     }
+
+    /// Produce a compact, human-readable description of this node.
+    ///
+    ///  Symbol   Description
+    /// --------|-------------
+    ///    B    |  Base
+    ///    ||   |  Concat
+    ///    ⧖    |  Latest
+    ///    γ    |  Group by
+    ///   |*|   |  Count
+    ///    𝛴    |  Sum
+    ///    ⋈    |  Join
+    ///    ⋉    |  Left join
+    ///    ⋃    |  Union
+    fn description(&self) -> String;
 }
 
 /// The set of node types supported by distributary.
@@ -270,6 +285,22 @@ impl NodeOp for NodeType {
             false
         }
     }
+
+    fn description(&self) -> String {
+        match *self {
+            NodeType::Base(ref n) => n.description(),
+            NodeType::Aggregate(ref n) => n.description(),
+            NodeType::Join(ref n) => n.description(),
+            NodeType::Latest(ref n) => n.description(),
+            NodeType::Union(ref n) => n.description(),
+            NodeType::Identity(ref n) => n.description(),
+            NodeType::GroupConcat(ref n) => n.description(),
+            #[cfg(test)]
+            NodeType::Test(ref n) => n.description(),
+            #[cfg(test)]
+            NodeType::GatedIdentity(ref n) => n.description(),
+        }
+    }
 }
 
 impl Debug for NodeType {
@@ -315,7 +346,7 @@ impl Node {
 
 impl Debug for Node {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.name)
+        write!(f, "{:?}({:#?})", self.name, self.inner)
     }
 }
 
@@ -567,6 +598,10 @@ mod tests {
 
         fn resolve(&self, _: usize) -> Option<Vec<(flow::NodeIndex, usize)>> {
             None
+        }
+
+        fn description(&self) -> String {
+            "Tester".into()
         }
     }
     fn e2e_test(mat: bool) {

--- a/src/ops/union.rs
+++ b/src/ops/union.rs
@@ -176,6 +176,20 @@ impl NodeOp for Union {
     fn resolve(&self, col: usize) -> Option<Vec<(flow::NodeIndex, usize)>> {
         Some(self.emit.iter().map(|(src, emit)| (*src, emit[col])).collect())
     }
+
+    fn description(&self) -> String {
+        // Ensure we get a consistent output by sorting.
+        let mut emit = self.emit.iter().collect::<Vec<_>>();
+        emit.sort();
+        emit.iter()
+            .map(|&(src, emit)| {
+                let cols = emit.iter().map(|e| e.to_string())
+                    .collect::<Vec<_>>().join(", ");
+                format!("{}:[{}]", src.index(), cols)
+            })
+            .collect::<Vec<_>>()
+            .join(" ⋃ ")
+    }
 }
 
 #[cfg(test)]
@@ -221,6 +235,12 @@ mod tests {
         let mut c = Union::new(emits);
         c.prime(&g);
         (ops::new("union", &["u0", "u1"], false, c), l, r)
+    }
+
+    #[test]
+    fn it_describes() {
+        let (u, _, _) = setup();
+        assert_eq!(u.inner.description(), "0:[0, 1] ⋃ 1:[0, 2]");
     }
 
     #[test]


### PR DESCRIPTION
Output DOT graphs without using petgraph's stock formatter so that we
can output each node's configuration using a dense, human-readable,
relational-algebra-like format.

Here's what the main/web graph looks like in this new world:

![dot-example](https://cloud.githubusercontent.com/assets/882976/20197662/a3640162-a76e-11e6-8082-42d94034473d.png)
