### PR TITLE
Type: fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ executing data-flow operators (`noria-server/dataflow`). The code in
 establishing materializations, scheduling data-flow work, orchestrating
 Noria program changes, handling failovers, etc.
 
-[`noria-server/lib.rs`](src/lib.rs) has a pretty extensive comment at
+[`noria-server/lib.rs`](noria-server/src/lib.rs) has a pretty extensive comment at
 the top of it that goes through how the Noria internals fit together at
 an implementation level. While it occasionally lags behind, especially
 following larger changes, it should serve to get you familiarized with


### PR DESCRIPTION
This is straight forward, but makes getting up to speed less of a burden :) 