### PR TITLE
Support for UnsignedInt & UnsignedBigInt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ dependencies = [
  "hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)",
+ "nom-sql 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "noria 0.1.2",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rahashmap 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1246,7 +1246,7 @@ version = "0.1.0"
 dependencies = [
  "common 0.1.0",
  "dataflow 0.1.0",
- "nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)",
+ "nom-sql 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1401,8 +1401,8 @@ dependencies = [
 
 [[package]]
 name = "nom-sql"
-version = "0.0.7"
-source = "git+https://github.com/ms705/nom-sql.git#0c02b70263b087aae8f68ab19a8a1efdc05695c9"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1426,7 +1426,7 @@ dependencies = [
  "hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)",
+ "nom-sql 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1464,7 +1464,7 @@ dependencies = [
  "memcached-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "mysql 16.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)",
+ "nom-sql 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "noria-server 0.1.0",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1507,7 +1507,7 @@ dependencies = [
  "mir 0.1.0",
  "mysql 16.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)",
+ "nom-sql 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "noria 0.1.2",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3381,7 +3381,7 @@ dependencies = [
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)" = "<none>"
+"checksum nom-sql 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6574668f96301752a17a792bbe4754607d6d105fe3dd4e1d7cbb1c57aade2564"
 "checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ dependencies = [
  "hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom-sql 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)",
  "noria 0.1.2",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rahashmap 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1246,7 +1246,7 @@ version = "0.1.0"
 dependencies = [
  "common 0.1.0",
  "dataflow 0.1.0",
- "nom-sql 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "nom-sql"
 version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/ms705/nom-sql.git#0c02b70263b087aae8f68ab19a8a1efdc05695c9"
 dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1426,7 +1426,7 @@ dependencies = [
  "hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom-sql 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1464,7 +1464,7 @@ dependencies = [
  "memcached-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "mysql 16.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom-sql 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)",
  "noria-server 0.1.0",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1507,7 +1507,7 @@ dependencies = [
  "mir 0.1.0",
  "mysql 16.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom-sql 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)",
  "noria 0.1.2",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3381,7 +3381,7 @@ dependencies = [
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum nom-sql 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6e7ef8ce452d73ba00330c9b76a406fe2aadde49e1632409e7183029e83bed14"
+"checksum nom-sql 0.0.7 (git+https://github.com/ms705/nom-sql.git)" = "<none>"
 "checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"

--- a/noria-benchmarks/Cargo.toml
+++ b/noria-benchmarks/Cargo.toml
@@ -11,7 +11,7 @@ orchestration = ["rusoto_core", "rusoto_sts", "tsunami"]
 [dependencies]
 chrono = { version = "0.4.0", features = ["serde"] }
 noria = { path = "../noria-server", package = "noria-server" }
-nom-sql = "0.0.7"
+nom-sql = { git = "https://github.com/ms705/nom-sql.git", branch = "master" }
 regex = "1.0.0"
 itertools = "0.8"
 slog = "2.4.0"

--- a/noria-benchmarks/Cargo.toml
+++ b/noria-benchmarks/Cargo.toml
@@ -11,7 +11,7 @@ orchestration = ["rusoto_core", "rusoto_sts", "tsunami"]
 [dependencies]
 chrono = { version = "0.4.0", features = ["serde"] }
 noria = { path = "../noria-server", package = "noria-server" }
-nom-sql = { git = "https://github.com/ms705/nom-sql.git", branch = "master" }
+nom-sql = "0.0.8"
 regex = "1.0.0"
 itertools = "0.8"
 slog = "2.4.0"

--- a/noria-benchmarks/replay/main.rs
+++ b/noria-benchmarks/replay/main.rs
@@ -133,14 +133,14 @@ fn perform_primary_reads(
     let mut getter = g.view("ReadRow").unwrap().into_sync();
 
     for i in row_ids {
-        let id: DataType = DataType::BigInt(i as i128);
+        let id: DataType = DataType::UnsignedBigInt(i as u64);
         let start = Instant::now();
         let rs = getter.lookup(&[id], true).unwrap();
         let elapsed = start.elapsed();
         let us = elapsed.as_secs() * 1_000_000 + u64::from(elapsed.subsec_nanos()) / 1_000;
         assert_eq!(rs.len(), 1);
         for j in 0..10 {
-            assert_eq!(DataType::BigInt(i as i128), rs[0][j]);
+            assert_eq!(DataType::UnsignedBigInt(i as u64), rs[0][j]);
         }
 
         if hist.record(us).is_err() {
@@ -164,7 +164,7 @@ fn perform_secondary_reads(
 
     let skewed = row_ids.len() == 1;
     for i in row_ids {
-        let id: DataType = DataType::BigInt(i as i128);
+        let id: DataType = DataType::UnsignedBigInt(i as u64);
         let start = Instant::now();
         // Pick an arbitrary secondary index to use:
         let getter = &mut getters[i as usize % (indices - 1)];
@@ -178,7 +178,7 @@ fn perform_secondary_reads(
         }
 
         for j in 0..10 {
-            assert_eq!(DataType::BigInt(i as i128), rs[0][j]);
+            assert_eq!(DataType::UnsignedBigInt(i as u64), rs[0][j]);
         }
 
         if hist.record(us).is_err() {

--- a/noria-benchmarks/replay/main.rs
+++ b/noria-benchmarks/replay/main.rs
@@ -133,14 +133,14 @@ fn perform_primary_reads(
     let mut getter = g.view("ReadRow").unwrap().into_sync();
 
     for i in row_ids {
-        let id: DataType = DataType::BigInt(i);
+        let id: DataType = DataType::BigInt(i as i128);
         let start = Instant::now();
         let rs = getter.lookup(&[id], true).unwrap();
         let elapsed = start.elapsed();
         let us = elapsed.as_secs() * 1_000_000 + u64::from(elapsed.subsec_nanos()) / 1_000;
         assert_eq!(rs.len(), 1);
         for j in 0..10 {
-            assert_eq!(DataType::BigInt(i), rs[0][j]);
+            assert_eq!(DataType::BigInt(i as i128), rs[0][j]);
         }
 
         if hist.record(us).is_err() {
@@ -164,7 +164,7 @@ fn perform_secondary_reads(
 
     let skewed = row_ids.len() == 1;
     for i in row_ids {
-        let id: DataType = DataType::BigInt(i);
+        let id: DataType = DataType::BigInt(i as i128);
         let start = Instant::now();
         // Pick an arbitrary secondary index to use:
         let getter = &mut getters[i as usize % (indices - 1)];
@@ -178,7 +178,7 @@ fn perform_secondary_reads(
         }
 
         for j in 0..10 {
-            assert_eq!(DataType::BigInt(i), rs[0][j]);
+            assert_eq!(DataType::BigInt(i as i128), rs[0][j]);
         }
 
         if hist.record(us).is_err() {

--- a/noria-server/Cargo.toml
+++ b/noria-server/Cargo.toml
@@ -20,7 +20,7 @@ hostname = "0.1.3"
 hyper = "0.12.0"
 mio = "0.6.9"
 nom = "^4.0.0"
-nom-sql = "0.0.7"
+nom-sql = { git = "https://github.com/ms705/nom-sql.git", branch = "master" }
 petgraph = { version = "0.4.11", features = ["serde-1"] }
 rand = "0.7.0"
 serde_derive = "1.0.8"

--- a/noria-server/Cargo.toml
+++ b/noria-server/Cargo.toml
@@ -20,7 +20,7 @@ hostname = "0.1.3"
 hyper = "0.12.0"
 mio = "0.6.9"
 nom = "^4.0.0"
-nom-sql = { git = "https://github.com/ms705/nom-sql.git", branch = "master" }
+nom-sql = "0.0.8"
 petgraph = { version = "0.4.11", features = ["serde-1"] }
 rand = "0.7.0"
 serde_derive = "1.0.8"

--- a/noria-server/dataflow/Cargo.toml
+++ b/noria-server/dataflow/Cargo.toml
@@ -10,7 +10,7 @@ evmap = { git = "https://github.com/jonhoo/rust-evmap", branch = "eviction" }
 fnv = "1.0.5"
 futures = "0.1"
 itertools = "0.8"
-nom-sql = { git = "https://github.com/ms705/nom-sql.git", branch = "master" }
+nom-sql = "0.0.8"
 rahashmap = "0.2.13"
 rand = "0.7"
 regex = "1"

--- a/noria-server/dataflow/Cargo.toml
+++ b/noria-server/dataflow/Cargo.toml
@@ -10,7 +10,7 @@ evmap = { git = "https://github.com/jonhoo/rust-evmap", branch = "eviction" }
 fnv = "1.0.5"
 futures = "0.1"
 itertools = "0.8"
-nom-sql = "0.0.7"
+nom-sql = { git = "https://github.com/ms705/nom-sql.git", branch = "master" }
 rahashmap = "0.2.13"
 rand = "0.7"
 regex = "1"

--- a/noria-server/dataflow/src/node/special/base.rs
+++ b/noria-server/dataflow/src/node/special/base.rs
@@ -240,8 +240,8 @@ impl Base {
                 match op {
                     Modification::Set(v) => future[col] = v,
                     Modification::Apply(op, v) => {
-                        let old: i64 = future[col].clone().into();
-                        let delta: i64 = v.into();
+                        let old: i128 = future[col].clone().into();
+                        let delta: i128 = v.into();
                         future[col] = match op {
                             Operation::Add => (old + delta).into(),
                             Operation::Sub => (old - delta).into(),

--- a/noria-server/dataflow/src/ops/grouped/aggregate.rs
+++ b/noria-server/dataflow/src/ops/grouped/aggregate.rs
@@ -60,7 +60,7 @@ pub struct Aggregator {
 }
 
 impl GroupedOperation for Aggregator {
-    type Diff = i64;
+    type Diff = i128;
 
     fn setup(&mut self, parent: &Node) {
         assert!(
@@ -79,7 +79,7 @@ impl GroupedOperation for Aggregator {
             Aggregation::COUNT => -1,
             Aggregation::SUM => {
                 let v = match r[self.over] {
-                    DataType::Int(n) => i64::from(n),
+                    DataType::Int(n) => i128::from(n),
                     DataType::BigInt(n) => n,
                     DataType::None => 0,
                     ref x => unreachable!("tried to aggregate over {:?} on {:?}", x, r),
@@ -87,7 +87,7 @@ impl GroupedOperation for Aggregator {
                 if pos {
                     v
                 } else {
-                    0i64 - v
+                    0i128 - v
                 }
             }
         }
@@ -99,7 +99,7 @@ impl GroupedOperation for Aggregator {
         diffs: &mut dyn Iterator<Item = Self::Diff>,
     ) -> DataType {
         let n = match current {
-            Some(&DataType::Int(n)) => i64::from(n),
+            Some(&DataType::Int(n)) => i128::from(n),
             Some(&DataType::BigInt(n)) => n,
             None => 0,
             _ => unreachable!(),

--- a/noria-server/dataflow/src/ops/grouped/aggregate.rs
+++ b/noria-server/dataflow/src/ops/grouped/aggregate.rs
@@ -80,7 +80,9 @@ impl GroupedOperation for Aggregator {
             Aggregation::SUM => {
                 let v = match r[self.over] {
                     DataType::Int(n) => i128::from(n),
-                    DataType::BigInt(n) => n,
+                    DataType::UnsignedInt(n) => i128::from(n),
+                    DataType::BigInt(n) => i128::from(n),
+                    DataType::UnsignedBigInt(n) => i128::from(n),
                     DataType::None => 0,
                     ref x => unreachable!("tried to aggregate over {:?} on {:?}", x, r),
                 };
@@ -100,7 +102,9 @@ impl GroupedOperation for Aggregator {
     ) -> DataType {
         let n = match current {
             Some(&DataType::Int(n)) => i128::from(n),
-            Some(&DataType::BigInt(n)) => n,
+            Some(&DataType::UnsignedInt(n)) => i128::from(n),
+            Some(&DataType::BigInt(n)) => i128::from(n),
+            Some(&DataType::UnsignedBigInt(n)) => i128::from(n),
             None => 0,
             _ => unreachable!(),
         };

--- a/noria-server/dataflow/src/ops/grouped/concat.rs
+++ b/noria-server/dataflow/src/ops/grouped/concat.rs
@@ -95,7 +95,9 @@ impl GroupConcat {
                         s.push_str(&*text);
                     }
                     DataType::Int(ref n) => s.push_str(&n.to_string()),
+                    DataType::UnsignedInt(ref n) => s.push_str(&n.to_string()),
                     DataType::BigInt(ref n) => s.push_str(&n.to_string()),
+                    DataType::UnsignedBigInt(ref n) => s.push_str(&n.to_string()),
                     DataType::Real(..) => s.push_str(&rec[*i].to_string()),
                     DataType::Timestamp(ref ts) => s.push_str(&ts.format("%+").to_string()),
                     DataType::None => unreachable!(),

--- a/noria-server/dataflow/src/ops/grouped/extremum.rs
+++ b/noria-server/dataflow/src/ops/grouped/extremum.rs
@@ -59,8 +59,8 @@ pub struct ExtremumOperator {
 }
 
 pub enum DiffType {
-    Insert(i64),
-    Remove(i64),
+    Insert(i128),
+    Remove(i128),
 }
 
 impl GroupedOperation for ExtremumOperator {
@@ -79,7 +79,7 @@ impl GroupedOperation for ExtremumOperator {
 
     fn to_diff(&self, r: &[DataType], pos: bool) -> Self::Diff {
         let v = match r[self.over] {
-            DataType::Int(n) => i64::from(n),
+            DataType::Int(n) => i128::from(n),
             DataType::BigInt(n) => n,
             _ => {
                 // the column we're aggregating over is non-numerical (or rather, this value is).
@@ -109,19 +109,19 @@ impl GroupedOperation for ExtremumOperator {
     ) -> DataType {
         // Extreme values are those that are at least as extreme as the current min/max (if any).
         // let mut is_extreme_value : Box<dyn Fn(i64) -> bool> = Box::new(|_|true);
-        let mut extreme_values: Vec<i64> = vec![];
+        let mut extreme_values: Vec<i128> = vec![];
         if let Some(data) = current {
             match *data {
-                DataType::Int(n) => extreme_values.push(i64::from(n)),
+                DataType::Int(n) => extreme_values.push(i128::from(n)),
                 DataType::BigInt(n) => extreme_values.push(n),
                 _ => unreachable!(),
             }
         };
 
-        let is_extreme_value = |x: i64| {
+        let is_extreme_value = |x: i128| {
             if let Some(data) = current {
                 let n = match *data {
-                    DataType::Int(n) => i64::from(n),
+                    DataType::Int(n) => i128::from(n),
                     DataType::BigInt(n) => n,
                     _ => unreachable!(),
                 };
@@ -138,7 +138,7 @@ impl GroupedOperation for ExtremumOperator {
             match d {
                 DiffType::Insert(v) if is_extreme_value(v) => extreme_values.push(v),
                 DiffType::Remove(v) if is_extreme_value(v) => {
-                    if let Some(i) = extreme_values.iter().position(|x: &i64| *x == v) {
+                    if let Some(i) = extreme_values.iter().position(|x: &i128| *x == v) {
                         extreme_values.swap_remove(i);
                     }
                 }

--- a/noria-server/dataflow/src/ops/grouped/extremum.rs
+++ b/noria-server/dataflow/src/ops/grouped/extremum.rs
@@ -80,7 +80,9 @@ impl GroupedOperation for ExtremumOperator {
     fn to_diff(&self, r: &[DataType], pos: bool) -> Self::Diff {
         let v = match r[self.over] {
             DataType::Int(n) => i128::from(n),
-            DataType::BigInt(n) => n,
+            DataType::UnsignedInt(n) => i128::from(n),
+            DataType::BigInt(n) => i128::from(n),
+            DataType::UnsignedBigInt(n) => i128::from(n),
             _ => {
                 // the column we're aggregating over is non-numerical (or rather, this value is).
                 // if you've removed a column, chances are the  default value has the wrong type.
@@ -113,7 +115,9 @@ impl GroupedOperation for ExtremumOperator {
         if let Some(data) = current {
             match *data {
                 DataType::Int(n) => extreme_values.push(i128::from(n)),
-                DataType::BigInt(n) => extreme_values.push(n),
+                DataType::UnsignedInt(n) => extreme_values.push(i128::from(n)),
+                DataType::BigInt(n) => extreme_values.push(i128::from(n)),
+                DataType::UnsignedBigInt(n) => extreme_values.push(i128::from(n)),
                 _ => unreachable!(),
             }
         };
@@ -122,7 +126,9 @@ impl GroupedOperation for ExtremumOperator {
             if let Some(data) = current {
                 let n = match *data {
                     DataType::Int(n) => i128::from(n),
-                    DataType::BigInt(n) => n,
+                    DataType::UnsignedInt(n) => i128::from(n),
+                    DataType::BigInt(n) => i128::from(n),
+                    DataType::UnsignedBigInt(n) => i128::from(n),
                     _ => unreachable!(),
                 };
                 match self.op {

--- a/noria-server/mir/Cargo.toml
+++ b/noria-server/mir/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Noria developers <noria@pdos.csail.mit.edu>"]
 publish = false
 
 [dependencies]
-nom-sql = { git = "https://github.com/ms705/nom-sql.git", branch = "master" }
+nom-sql = "0.0.8"
 regex = "1.0.0"
 slog = "2.4.0"
 petgraph = { version = "0.4.11", features = ["serde-1"] }

--- a/noria-server/mir/Cargo.toml
+++ b/noria-server/mir/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["The Noria developers <noria@pdos.csail.mit.edu>"]
 publish = false
 
 [dependencies]
-nom-sql = "0.0.7"
-regex = "1"
+nom-sql = { git = "https://github.com/ms705/nom-sql.git", branch = "master" }
+regex = "1.0.0"
 slog = "2.4.0"
 petgraph = { version = "0.4.11", features = ["serde-1"] }
 

--- a/noria-server/src/controller/schema.rs
+++ b/noria-server/src/controller/schema.rs
@@ -14,7 +14,9 @@ type Path = std::vec::Vec<(
 fn to_sql_type(d: &DataType) -> Option<SqlType> {
     match d {
         DataType::Int(_) => Some(SqlType::Int(32)),
+        DataType::UnsignedInt(_) => Some(SqlType::Int(32)), // TODO support sign
         DataType::BigInt(_) => Some(SqlType::Bigint(64)),
+        DataType::UnsignedBigInt(_) => Some(SqlType::Bigint(64)), // TODO support sign
         DataType::Real(_, _) => Some(SqlType::Real),
         DataType::Text(_) => Some(SqlType::Text),
         DataType::TinyText(_) => Some(SqlType::Varchar(8)),

--- a/noria-server/src/controller/schema.rs
+++ b/noria-server/src/controller/schema.rs
@@ -13,11 +13,11 @@ type Path = std::vec::Vec<(
 
 fn to_sql_type(d: &DataType) -> Option<SqlType> {
     match d {
-        DataType::Int(_) => Some(SqlType::Int(32)),
-        DataType::UnsignedInt(_) => Some(SqlType::Int(32)), // TODO support sign
-        DataType::BigInt(_) => Some(SqlType::Bigint(64)),
-        DataType::UnsignedBigInt(_) => Some(SqlType::Bigint(64)), // TODO support sign
-        DataType::Real(_, _) => Some(SqlType::Real),
+        DataType::Int(_) => Some(SqlType::Int(32, true)),
+        DataType::UnsignedInt(_) => Some(SqlType::Int(32, false)),
+        DataType::BigInt(_) => Some(SqlType::Bigint(64, true)),
+        DataType::UnsignedBigInt(_) => Some(SqlType::Bigint(64, false)),
+        DataType::Real(_, _) => Some(SqlType::Real(true)),
         DataType::Text(_) => Some(SqlType::Text),
         DataType::TinyText(_) => Some(SqlType::Varchar(8)),
         // TODO(malte): There is no SqlType for `NULL` (as it's not a
@@ -45,7 +45,7 @@ fn type_for_internal_column(
                 // computed expression
                 // TODO(malte): trace the actual column types, since this could be a
                 // real-valued arithmetic operation
-                Some(SqlType::Bigint(64))
+                Some(SqlType::Bigint(64, true))
             } else {
                 // literal
                 let off = column_index - (emits.0.len() + emits.2.len());
@@ -56,7 +56,7 @@ fn type_for_internal_column(
             // computed column is always emitted last
             if column_index == node.fields().len() - 1 {
                 // counts and sums always produce integral columns
-                Some(SqlType::Bigint(64))
+                Some(SqlType::Bigint(64, true))
             } else {
                 // no column that isn't the aggregation result column should ever trace
                 // back to an aggregation.

--- a/noria-server/src/controller/schema.rs
+++ b/noria-server/src/controller/schema.rs
@@ -13,11 +13,11 @@ type Path = std::vec::Vec<(
 
 fn to_sql_type(d: &DataType) -> Option<SqlType> {
     match d {
-        DataType::Int(_) => Some(SqlType::Int(32, true)),
-        DataType::UnsignedInt(_) => Some(SqlType::Int(32, false)),
-        DataType::BigInt(_) => Some(SqlType::Bigint(64, true)),
-        DataType::UnsignedBigInt(_) => Some(SqlType::Bigint(64, false)),
-        DataType::Real(_, _) => Some(SqlType::Real(true)),
+        DataType::Int(_) => Some(SqlType::Int(32)),
+        DataType::UnsignedInt(_) => Some(SqlType::UnsignedInt(32)),
+        DataType::BigInt(_) => Some(SqlType::Bigint(64)),
+        DataType::UnsignedBigInt(_) => Some(SqlType::UnsignedBigint(64)),
+        DataType::Real(_, _) => Some(SqlType::Real),
         DataType::Text(_) => Some(SqlType::Text),
         DataType::TinyText(_) => Some(SqlType::Varchar(8)),
         // TODO(malte): There is no SqlType for `NULL` (as it's not a
@@ -45,7 +45,7 @@ fn type_for_internal_column(
                 // computed expression
                 // TODO(malte): trace the actual column types, since this could be a
                 // real-valued arithmetic operation
-                Some(SqlType::Bigint(64, true))
+                Some(SqlType::Bigint(64))
             } else {
                 // literal
                 let off = column_index - (emits.0.len() + emits.2.len());
@@ -56,7 +56,7 @@ fn type_for_internal_column(
             // computed column is always emitted last
             if column_index == node.fields().len() - 1 {
                 // counts and sums always produce integral columns
-                Some(SqlType::Bigint(64, true))
+                Some(SqlType::Bigint(64))
             } else {
                 // no column that isn't the aggregation result column should ever trace
                 // back to an aggregation.

--- a/noria-server/src/integration.rs
+++ b/noria-server/src/integration.rs
@@ -2508,9 +2508,9 @@ fn correct_nested_view_schema() {
     let q = g.view("swvc").unwrap().into_sync();
 
     let expected_schema = vec![
-        ColumnSpecification::new("swvc.id".into(), SqlType::Int(32, true)),
+        ColumnSpecification::new("swvc.id".into(), SqlType::Int(32)),
         ColumnSpecification::new("swvc.content".into(), SqlType::Text),
-        ColumnSpecification::new("swvc.vc".into(), SqlType::Bigint(64, true)),
+        ColumnSpecification::new("swvc.vc".into(), SqlType::Bigint(64)),
     ];
     assert_eq!(q.schema(), Some(&expected_schema[..]));
 }

--- a/noria-server/src/integration.rs
+++ b/noria-server/src/integration.rs
@@ -2508,9 +2508,9 @@ fn correct_nested_view_schema() {
     let q = g.view("swvc").unwrap().into_sync();
 
     let expected_schema = vec![
-        ColumnSpecification::new("swvc.id".into(), SqlType::Int(32)),
+        ColumnSpecification::new("swvc.id".into(), SqlType::Int(32, true)),
         ColumnSpecification::new("swvc.content".into(), SqlType::Text),
-        ColumnSpecification::new("swvc.vc".into(), SqlType::Bigint(64)),
+        ColumnSpecification::new("swvc.vc".into(), SqlType::Bigint(64, true)),
     ];
     assert_eq!(q.schema(), Some(&expected_schema[..]));
 }

--- a/noria-server/tests/mysql_comparison.rs
+++ b/noria-server/tests/mysql_comparison.rs
@@ -310,7 +310,9 @@ fn check_query(
                     .map(|v| match v {
                         DataType::None => "NULL".to_owned(),
                         DataType::Int(i) => i.to_string(),
+                        DataType::UnsignedInt(i) => i.to_string(),
                         DataType::BigInt(i) => i.to_string(),
+                        DataType::UnsignedBigInt(i) => i.to_string(),
                         DataType::Real(i, f) => ((i as f64) + (f as f64) * 1.0e-9).to_string(),
                         DataType::Text(_) | DataType::TinyText(_) => v.into(),
                         DataType::Timestamp(_) => unimplemented!(),

--- a/noria/Cargo.toml
+++ b/noria/Cargo.toml
@@ -23,7 +23,7 @@ assert_infrequent = "0.1.0"
 failure = "0.1"
 futures = "0.1.16"
 hyper = "0.12.0"
-nom-sql = { git = "https://github.com/ms705/nom-sql.git", branch = "master" }
+nom-sql = "0.0.8"
 serde = { version = "1.0.8", features = ["rc"] }
 serde_derive = "1.0.8"
 serde_json = "1.0.2"

--- a/noria/Cargo.toml
+++ b/noria/Cargo.toml
@@ -23,7 +23,7 @@ assert_infrequent = "0.1.0"
 failure = "0.1"
 futures = "0.1.16"
 hyper = "0.12.0"
-nom-sql = "0.0.7"
+nom-sql = { git = "https://github.com/ms705/nom-sql.git", branch = "master" }
 serde = { version = "1.0.8", features = ["rc"] }
 serde_derive = "1.0.8"
 serde_json = "1.0.2"

--- a/noria/src/data.rs
+++ b/noria/src/data.rs
@@ -27,7 +27,7 @@ pub enum DataType {
     /// A 32-bit numeric value.
     Int(i32),
     /// A 64-bit numeric value.
-    BigInt(i64),
+    BigInt(i128),
     /// A fixed point real value. The first field is the integer part, while the second is the
     /// fractional and must be between -999999999 and 999999999.
     Real(i64, i32),
@@ -164,8 +164,8 @@ impl PartialEq for DataType {
             (&DataType::Int(a), &DataType::Int(b)) => a == b,
             (&DataType::BigInt(..), &DataType::Int(..))
             | (&DataType::Int(..), &DataType::BigInt(..)) => {
-                let a: i64 = self.into();
-                let b: i64 = other.into();
+                let a: i128 = self.into();
+                let b: i128 = other.into();
                 a == b
             }
             (&DataType::Real(ai, af), &DataType::Real(bi, bf)) => ai == bi && af == bf,
@@ -199,8 +199,8 @@ impl Ord for DataType {
             (&DataType::Int(a), &DataType::Int(b)) => a.cmp(&b),
             (&DataType::BigInt(..), &DataType::Int(..))
             | (&DataType::Int(..), &DataType::BigInt(..)) => {
-                let a: i64 = self.into();
-                let b: i64 = other.into();
+                let a: i128 = self.into();
+                let b: i128 = other.into();
                 a.cmp(&b)
             }
             (&DataType::Real(ai, af), &DataType::Real(ref bi, ref bf)) => {
@@ -227,7 +227,7 @@ impl Hash for DataType {
         match *self {
             DataType::None => {}
             DataType::Int(..) | DataType::BigInt(..) => {
-                let n: i64 = self.into();
+                let n: i128 = self.into();
                 n.hash(state)
             }
             DataType::Real(i, f) => {
@@ -243,9 +243,15 @@ impl Hash for DataType {
     }
 }
 
+impl From<i128> for DataType {
+    fn from(s: i128) -> Self {
+        DataType::BigInt(s)
+    }
+}
+
 impl From<i64> for DataType {
     fn from(s: i64) -> Self {
-        DataType::BigInt(s)
+        DataType::BigInt(i128::from(s))
     }
 }
 
@@ -351,21 +357,21 @@ impl Into<String> for DataType {
     }
 }
 
-impl Into<i64> for DataType {
-    fn into(self) -> i64 {
+impl Into<i128> for DataType {
+    fn into(self) -> i128 {
         match self {
             DataType::BigInt(s) => s,
-            DataType::Int(s) => i64::from(s),
+            DataType::Int(s) => i128::from(s),
             _ => unreachable!(),
         }
     }
 }
 
-impl<'a> Into<i64> for &'a DataType {
-    fn into(self) -> i64 {
+impl<'a> Into<i128> for &'a DataType {
+    fn into(self) -> i128 {
         match *self {
             DataType::BigInt(s) => s,
-            DataType::Int(s) => i64::from(s),
+            DataType::Int(s) => i128::from(s),
             _ => unreachable!(),
         }
     }
@@ -423,8 +429,8 @@ macro_rules! arithmetic_operation (
             (&DataType::None, _) | (_, &DataType::None) => DataType::None,
             (&DataType::Int(a), &DataType::Int(b)) => (a $op b).into(),
             (&DataType::BigInt(a), &DataType::BigInt(b)) => (a $op b).into(),
-            (&DataType::Int(a), &DataType::BigInt(b)) => (i64::from(a) $op b).into(),
-            (&DataType::BigInt(a), &DataType::Int(b)) => (a $op i64::from(b)).into(),
+            (&DataType::Int(a), &DataType::BigInt(b)) => (i128::from(a) $op b).into(),
+            (&DataType::BigInt(a), &DataType::Int(b)) => (a $op i128::from(b)).into(),
 
             (first @ &DataType::Int(..), second @ &DataType::Real(..)) |
             (first @ &DataType::Real(..), second @ &DataType::Int(..)) |

--- a/noria/src/data.rs
+++ b/noria/src/data.rs
@@ -516,13 +516,20 @@ macro_rules! arithmetic_operation (
         match ($first, $second) {
             (&DataType::None, _) | (_, &DataType::None) => DataType::None,
             (&DataType::Int(a), &DataType::Int(b)) => (a $op b).into(),
+            (&DataType::UnsignedInt(a), &DataType::UnsignedInt(b)) => (a $op b).into(),
             (&DataType::BigInt(a), &DataType::BigInt(b)) => (a $op b).into(),
+            (&DataType::UnsignedBigInt(a), &DataType::UnsignedBigInt(b)) => (a $op b).into(),
             (&DataType::Int(a), &DataType::BigInt(b)) => (i64::from(a) $op b).into(),
+            (&DataType::Int(a), &DataType::UnsignedBigInt(b)) => (i128::from(a) $op i128::from(b)).into(),
             (&DataType::BigInt(a), &DataType::Int(b)) => (a $op i64::from(b)).into(),
-            // TODO ADD SUPPORT FOR MATHS ON SIGNED (Big)Int
+            (&DataType::UnsignedBigInt(a), &DataType::Int(b)) => (i128::from(a) $op i128::from(b)).into(),
+            (&DataType::UnsignedBigInt(a), &DataType::UnsignedInt(b)) => (a $op u64::from(b)).into(),
+            (&DataType::UnsignedInt(a), &DataType::UnsignedBigInt(b)) => (u64::from(a) $op b).into(),
 
             (first @ &DataType::Int(..), second @ &DataType::Real(..)) |
+            (first @ &DataType::UnsignedInt(..), second @ &DataType::Real(..)) |
             (first @ &DataType::Real(..), second @ &DataType::Int(..)) |
+            (first @ &DataType::Real(..), second @ &DataType::UnsignedInt(..)) |
             (first @ &DataType::Real(..), second @ &DataType::Real(..)) => {
                 let a: f64 = first.into();
                 let b: f64 = second.into();

--- a/noria/src/data.rs
+++ b/noria/src/data.rs
@@ -272,7 +272,11 @@ impl Hash for DataType {
 impl From<i128> for DataType {
     fn from(s: i128) -> Self {
         if s < 0 {
-            DataType::BigInt(s as i64)
+            if s >= std::i64::MIN.into() {
+                DataType::BigInt(s as i64)
+            } else {
+                panic!(format!("can't fit {:?} in a DataType::BigInt", s))
+            }
         } else {
             DataType::UnsignedBigInt(s as u64)
         }
@@ -527,9 +531,13 @@ macro_rules! arithmetic_operation (
             (&DataType::UnsignedInt(a), &DataType::UnsignedBigInt(b)) => (u64::from(a) $op b).into(),
 
             (first @ &DataType::Int(..), second @ &DataType::Real(..)) |
+            (first @ &DataType::BigInt(..), second @ &DataType::Real(..)) |
             (first @ &DataType::UnsignedInt(..), second @ &DataType::Real(..)) |
+            (first @ &DataType::UnsignedBigInt(..), second @ &DataType::Real(..)) |
             (first @ &DataType::Real(..), second @ &DataType::Int(..)) |
+            (first @ &DataType::Real(..), second @ &DataType::BigInt(..)) |
             (first @ &DataType::Real(..), second @ &DataType::UnsignedInt(..)) |
+            (first @ &DataType::Real(..), second @ &DataType::UnsignedBigInt(..)) |
             (first @ &DataType::Real(..), second @ &DataType::Real(..)) => {
                 let a: f64 = first.into();
                 let b: f64 = second.into();

--- a/noria/src/lib.rs
+++ b/noria/src/lib.rs
@@ -247,7 +247,9 @@ pub struct ActivationResult {
 pub fn shard_by(dt: &DataType, shards: usize) -> usize {
     match *dt {
         DataType::Int(n) => n as usize % shards,
+        DataType::UnsignedInt(n) => n as usize % shards,
         DataType::BigInt(n) => n as usize % shards,
+        DataType::UnsignedBigInt(n) => n as usize % shards,
         DataType::Text(..) | DataType::TinyText(..) => {
             use std::borrow::Cow;
             use std::hash::Hasher;


### PR DESCRIPTION
This is nowhere close to be merge'able, but I thought I'd use it to get the discussion going:

While trying to see how Noria would workout on a project, I hit an issue where `unsigned BigInt(20)` column types weren't properly supported. `nom-sql` had issues parsing the SQL while trying to load it all in Noria and threw `ParseIntError { kind: Overflow }` at us. 

I started hacking trying to get something working to at least get to load the the mysql dump into noria and make progress with the testing. Now here I am… `msql-srv` seems to deal with it fine (based on my limited reading of the code), but `nom-sql` less so. I'm more than willing to make progress on this, but would love to know what y'all take is on  adding the `DataType::Unsigned(Big)Int` is. Or would it be nicer to treat these as properties of the DataType itself, just like the "width"? `msql-srv` looks at it as flags on the column definition… Also what about the other "integer" types MySQL supports?

Anyways, I thought I'd get the discussion going already. In the meantime I'll try to make progress here… somehow. Tomorrow tho probably :)

wdyt? Or did I miss something entirely?