### PR TITLE
Refactored state impl via macro and trait

### DIFF
--- a/noria-server/dataflow/src/state/keyed_state.rs
+++ b/noria-server/dataflow/src/state/keyed_state.rs
@@ -2,6 +2,7 @@ use fnv::FnvBuildHasher;
 use rahashmap::HashMap as RaHashMap;
 use std::rc::Rc;
 
+use super::mk_key::MakeKey;
 use common::SizeOf;
 use prelude::*;
 
@@ -64,31 +65,11 @@ impl KeyedState {
     pub(super) fn evict(&mut self, key: &[DataType]) -> u64 {
         match *self {
             KeyedState::Single(ref mut m) => m.remove(&(key[0])),
-            KeyedState::Double(ref mut m) => m.remove(&(key[0].clone(), key[1].clone())),
-            KeyedState::Tri(ref mut m) => {
-                m.remove(&(key[0].clone(), key[1].clone(), key[2].clone()))
-            }
-            KeyedState::Quad(ref mut m) => m.remove(&(
-                key[0].clone(),
-                key[1].clone(),
-                key[2].clone(),
-                key[3].clone(),
-            )),
-            KeyedState::Quin(ref mut m) => m.remove(&(
-                key[0].clone(),
-                key[1].clone(),
-                key[2].clone(),
-                key[3].clone(),
-                key[4].clone(),
-            )),
-            KeyedState::Sex(ref mut m) => m.remove(&(
-                key[0].clone(),
-                key[1].clone(),
-                key[2].clone(),
-                key[3].clone(),
-                key[4].clone(),
-                key[5].clone(),
-            )),
+            KeyedState::Double(ref mut m) => m.remove(&MakeKey::from_key(key)),
+            KeyedState::Tri(ref mut m) => m.remove(&MakeKey::from_key(key)),
+            KeyedState::Quad(ref mut m) => m.remove(&MakeKey::from_key(key)),
+            KeyedState::Quin(ref mut m) => m.remove(&MakeKey::from_key(key)),
+            KeyedState::Sex(ref mut m) => m.remove(&MakeKey::from_key(key)),
         }
         .map(|rows| {
             rows.iter()

--- a/noria-server/dataflow/src/state/mk_key.rs
+++ b/noria-server/dataflow/src/state/mk_key.rs
@@ -1,0 +1,109 @@
+pub(super) trait MakeKey<A> {
+    fn from_row(key: &[usize], row: &[A]) -> Self;
+    fn from_key(key: &[A]) -> Self;
+}
+
+impl<A: Clone> MakeKey<A> for (A, A) {
+    #[inline(always)]
+    fn from_row(key: &[usize], row: &[A]) -> Self {
+        debug_assert_eq!(key.len(), 2);
+        (row[key[0]].clone(), row[key[1]].clone())
+    }
+    #[inline(always)]
+    fn from_key(key: &[A]) -> Self {
+        debug_assert_eq!(key.len(), 2);
+        (key[0].clone(), key[1].clone())
+    }
+}
+
+impl<A: Clone> MakeKey<A> for (A, A, A) {
+    #[inline(always)]
+    fn from_row(key: &[usize], row: &[A]) -> Self {
+        debug_assert_eq!(key.len(), 3);
+        (
+            row[key[0]].clone(),
+            row[key[1]].clone(),
+            row[key[2]].clone(),
+        )
+    }
+    #[inline(always)]
+    fn from_key(key: &[A]) -> Self {
+        debug_assert_eq!(key.len(), 3);
+        (key[0].clone(), key[1].clone(), key[2].clone())
+    }
+}
+
+impl<A: Clone> MakeKey<A> for (A, A, A, A) {
+    #[inline(always)]
+    fn from_row(key: &[usize], row: &[A]) -> Self {
+        debug_assert_eq!(key.len(), 4);
+        (
+            row[key[0]].clone(),
+            row[key[1]].clone(),
+            row[key[2]].clone(),
+            row[key[3]].clone(),
+        )
+    }
+    #[inline(always)]
+    fn from_key(key: &[A]) -> Self {
+        debug_assert_eq!(key.len(), 4);
+        (
+            key[0].clone(),
+            key[1].clone(),
+            key[2].clone(),
+            key[3].clone(),
+        )
+    }
+}
+
+impl<A: Clone> MakeKey<A> for (A, A, A, A, A) {
+    #[inline(always)]
+    fn from_row(key: &[usize], row: &[A]) -> Self {
+        debug_assert_eq!(key.len(), 5);
+        (
+            row[key[0]].clone(),
+            row[key[1]].clone(),
+            row[key[2]].clone(),
+            row[key[3]].clone(),
+            row[key[4]].clone(),
+        )
+    }
+    #[inline(always)]
+    fn from_key(key: &[A]) -> Self {
+        debug_assert_eq!(key.len(), 5);
+        (
+            key[0].clone(),
+            key[1].clone(),
+            key[2].clone(),
+            key[3].clone(),
+            key[4].clone(),
+        )
+    }
+}
+
+impl<A: Clone> MakeKey<A> for (A, A, A, A, A, A) {
+    #[inline(always)]
+    fn from_row(key: &[usize], row: &[A]) -> Self {
+        debug_assert_eq!(key.len(), 6);
+        (
+            row[key[0]].clone(),
+            row[key[1]].clone(),
+            row[key[2]].clone(),
+            row[key[3]].clone(),
+            row[key[4]].clone(),
+            row[key[5]].clone(),
+        )
+    }
+    #[inline(always)]
+    fn from_key(key: &[A]) -> Self {
+        debug_assert_eq!(key.len(), 6);
+        (
+            key[0].clone(),
+            key[1].clone(),
+            key[2].clone(),
+            key[3].clone(),
+            key[4].clone(),
+            key[5].clone(),
+        )
+    }
+}

--- a/noria-server/dataflow/src/state/mod.rs
+++ b/noria-server/dataflow/src/state/mod.rs
@@ -2,6 +2,7 @@ mod keyed_state;
 mod memory_state;
 mod persistent_state;
 mod single_state;
+mod mk_key;
 
 use std::borrow::Cow;
 use std::ops::Deref;

--- a/noria-server/dataflow/src/state/single_state.rs
+++ b/noria-server/dataflow/src/state/single_state.rs
@@ -13,7 +13,7 @@ pub(super) struct SingleState {
 }
 
 macro_rules! insert_row_match_impl {
-    ($self:expr, $r:expr, $map:expr) => {{
+    ($self:ident, $r:ident, $map:ident) => {{
         let key = MakeKey::from_row(&$self.key, &*$r);
         match $map.entry(key) {
             Entry::Occupied(mut rs) => rs.get_mut().push($r),
@@ -24,7 +24,7 @@ macro_rules! insert_row_match_impl {
 }
 
 macro_rules! remove_row_match_impl {
-    ($self:expr, $r:expr, $do_remove:expr, $map:expr) => {{
+    ($self:ident, $r:ident, $do_remove:ident, $map:ident) => {{
         // TODO: can we avoid the Clone here?
         let key = MakeKey::from_row(&$self.key, $r);
         if let Some(ref mut rs) = $map.get_mut(&key) {


### PR DESCRIPTION
The idea here is to make the conversion between `Row` (or `&[DataType]`) and an
index for the state map reusable, namely for other `State` impls.
It just so happens that that also allows me to apply some do-not-repeat-yourself
principles to the state impls using small `macro_rules`.

I did this change in preparation of implementing a custom `State`. I don't necessarily mean to suggest that this version is *better*, and *should* be merged` but I thought I'd inform you about the possibility.

The code isn't actually shorter, which I think is a bit unfortunate, but perhaps more readable. 