### PR TITLE
Disable all build caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 language: rust
-cache: cargo
+cache: false
 rust:
   - nightly-2019-06-18
 env:


### PR DESCRIPTION
As the title suggests.

All this does is completely turn off caching on travis-ci.org.
While this significantly increases build time (~27min) it means no more timeout errors when fetching the caches.