### PR TITLE
Disable jemalloc on windows to allow windows build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,12 +19,21 @@ stages:
             vmImage: ubuntu-16.04
           MacOS:
             vmImage: macOS-10.14
+          Windows:
+            vmImage: windows-2019
       pool:
         vmImage: $(vmImage)
       steps:
        - template: azure/install-rust.yml@templates
          parameters:
            rust: nightly
+       - powershell: |
+           Invoke-WebRequest http://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe -OutFile LLVM-9.0.0-win64.exe
+           ./LLVM-9.0.0-win64.exe /S
+           [Environment]::SetEnvironmentVariable("LIBCLANG_PATH", "$($env:SystemDrive)\Program Files\LLVM\bin", "Machine")
+         displayName: Windows install clang
+         condition: eq( variables['Agent.OS'], 'Windows_NT' )
+
        - script: cargo test --all -- --test-threads=1
          displayName: Run tests
          env:

--- a/noria-server/dataflow/Cargo.toml
+++ b/noria-server/dataflow/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["The Noria developers <noria@pdos.csail.mit.edu>"]
 publish = false
 
+[target.'cfg(not(target_env="msvc"))'.dependencies]
+jemallocator = "0.3"
+
 [dependencies]
 bincode = "1.0.0"
 evmap = { version = "7.1.0", features = ["indexed"] }
@@ -21,7 +24,6 @@ stream-cancel = "=0.5.0-alpha.4"
 tokio = "=0.2.0-alpha.6"
 vec_map = { version = "0.8.0", features = ["eders"] }
 tempfile = "3.0.2"
-jemallocator = "0.3"
 
 # need features
 backtrace = { version = "0.3.2", features = ["serialize-serde"] }

--- a/noria-server/dataflow/src/lib.rs
+++ b/noria-server/dataflow/src/lib.rs
@@ -8,6 +8,7 @@
 #![deny(unused_extern_crates)]
 #![allow(clippy::redundant_closure)]
 
+#[cfg(not(target_env="msvc"))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
This is work-around to enable `async-await` branch to be built on windows.

Proper fix would require fixing jemalloc build script (which is hard for msvc as jemalloc uses autoconf)