### PR TITLE
[NoriaCS2390] Implement Delete Logic

### DIFF
--- a/noria-server/dataflow/src/node/special/base.rs
+++ b/noria-server/dataflow/src/node/special/base.rs
@@ -211,6 +211,7 @@ impl Base {
                 }
                 TableOperation::Delete { .. } => {
                     if current.is_some() {
+                        // Todo: check for whether the deletePolicy is erasable (note by WY)
                         current = None;
                     } else {
                         // supposed to delete a non-existing row?

--- a/noria-server/dataflow/src/state/persistent_state.rs
+++ b/noria-server/dataflow/src/state/persistent_state.rs
@@ -16,8 +16,8 @@ type IndexEpoch = u64;
 type IndexSeq = u64;
 
 enum DelPolicy {
-    erasurable,
-    Unerasurable,   
+    erasable,
+    unerasable,   
 }
 
 // RocksDB key used for storing meta information (like indices).
@@ -35,6 +35,8 @@ const INDEX_BATCH_SIZE: usize = 100_000;
 struct PersistentMeta {
     indices: Vec<Vec<usize>>,
     epoch: IndexEpoch,
+    //todo: do we need to set deletePolicy here or should we add a parameter to the Table class?
+    // see noria/src/table.rs
     deletePolicy: DelPolicy,
 }
 

--- a/noria-server/dataflow/src/state/persistent_state.rs
+++ b/noria-server/dataflow/src/state/persistent_state.rs
@@ -15,6 +15,11 @@ type IndexEpoch = u64;
 // Monotonically increasing sequence number since last IndexEpoch used to uniquely identify a row.
 type IndexSeq = u64;
 
+enum DelPolicy {
+    erasurable,
+    Unerasurable,   
+}
+
 // RocksDB key used for storing meta information (like indices).
 const META_KEY: &[u8] = b"meta";
 // A default column family is always created, so we'll make use of that for meta information.
@@ -30,6 +35,7 @@ const INDEX_BATCH_SIZE: usize = 100_000;
 struct PersistentMeta {
     indices: Vec<Vec<usize>>,
     epoch: IndexEpoch,
+    deletePolicy: DelPolicy,
 }
 
 #[derive(Clone)]

--- a/noria/src/data.rs
+++ b/noria/src/data.rs
@@ -628,6 +628,7 @@ pub enum TableOperation {
     /// Delete a row with the contained key.
     Delete {
         /// The key.
+        /// TODO: do we need to change here? Note by WY
         key: Vec<DataType>,
     },
     /// If a row exists with the same key as the contained row, update it using `update`, otherwise

--- a/noria/src/lib.rs
+++ b/noria/src/lib.rs
@@ -94,6 +94,7 @@
 //! use [`ControllerHandle::table`] to get a handle to the new base table. Base tables support
 //! similar operations as SQL tables, such as [`Table::insert`], [`Table::update`],
 //! [`Table::delete`], and also more esoteric operations like [`Table::insert_or_update`].
+//! This file may be helpful- Note by WY
 //!
 //! # Synchronous and asynchronous operation
 //!


### PR DESCRIPTION
GDPR requires the application to delete User Data upon user requests. 
In this PR, I designed this logic:
(1) we requires the developer to specify one and only one special Table as the user_table. Only when developer sends sql query to delete user from this table, we will check every other table to delete the information for that particular user. 
This is why we requires every table to have a field called "is_user_table". Only one table's this field will be true. Only deleting from this table can trigger a checking of all other tables. 
(2)  when checking other tables, we check whether its field "contains_personal_info" is true, if false, we ignore this table. 
(3) for tables whose field "contains_personal_info == true", we continue to check whether table field "erasable == true", if not, ignore this table, otherwise, we delete all rows in this table that is associated with that user. 

An alternative is, instead of adding the field "is_user_table" to Table class, we require any application to have one table with table name "User". 