### PR TITLE
Add remove_query rpc

### DIFF
--- a/noria-server/src/controller/recipe/mod.rs
+++ b/noria-server/src/controller/recipe/mod.rs
@@ -650,7 +650,7 @@ impl Recipe {
         self.prior.as_ref().map(|p| &**p)
     }
 
-    fn remove_query(&mut self, qname: &str) -> bool {
+    crate fn remove_query(&mut self, qname: &str) -> bool {
         let qid = self.aliases.get(qname).cloned();
         if qid.is_none() {
             warn!(self.log, "Query {} not found in expressions", qname);

--- a/noria/src/controller.rs
+++ b/noria/src/controller.rs
@@ -447,6 +447,16 @@ impl<A: Authority + 'static> ControllerHandle<A> {
         self.rpc("remove_node", view, "failed to remove node")
     }
 
+    /// Remove the given query view from the graph.
+    ///
+    /// `Self::poll_ready` must have returned `Async::Ready` before you call this method.
+    pub fn remove_query(
+        &mut self,
+        view: &str,
+    ) -> impl Future<Item = (), Error = failure::Error> + Send {
+        self.rpc("remove_query", view, "failed to remove query")
+    }
+
     /// Construct a synchronous interface to this controller instance using the given executor to
     /// execute all operations.
     ///
@@ -634,6 +644,13 @@ where
     /// See [`ControllerHandle::remove_node`].
     pub fn remove_node(&mut self, view: NodeIndex) -> Result<(), failure::Error> {
         let fut = self.handle()?.remove_node(view);
+        self.run(fut)
+    }
+    /// Remove the given external view from the graph.
+    ///
+    /// See [`ControllerHandle::remove_node`].
+    pub fn remove_query(&mut self, view: &str) -> Result<(), failure::Error> {
+        let fut = self.handle()?.remove_query(view);
         self.run(fut)
     }
 }


### PR DESCRIPTION
Pushing for @ms705  to review why I get the error "thread 'worker-2' panicked at 'missing query hash for named query "answers_by_lec"', noria-server/src/controller/sql/mod.rs:574:32" when I register the third user. 