### PR TITLE
Added a conversion trait from mysql::Value to noria::DataType

### DIFF
--- a/noria/Cargo.toml
+++ b/noria/Cargo.toml
@@ -44,6 +44,7 @@ tracing-futures = "0.2.2"
 slab = "0.4"
 pin-project = "0.4.0"
 futures-util = "0.3.0"
+mysql = "18.1.0"
 
 # consensus/
 slog = "2.4.0"

--- a/noria/src/data.rs
+++ b/noria/src/data.rs
@@ -777,6 +777,14 @@ mod tests {
             DataType::Text(ArcCStr::try_from(&vec![1; 30][..]).unwrap())
         );
 
+        let mut s = [0; 15];
+        s[0] = 1;
+        s[1] = 2;
+        let a = mysql::Value::Bytes(s.to_vec());
+        let a_dt = DataType::try_from(a);
+        assert!(a_dt.is_ok());
+        assert_eq!(a_dt.unwrap(), DataType::TinyText(s));
+
         // Test Value::Int.
         let a = mysql::Value::Int(-5);
         let a_dt = DataType::try_from(a);


### PR DESCRIPTION
We need a conversion from `mysql::Value` to `noria::DataType` for write-policies in MultiverseDB, as insertions by the client must be applied to *MySQL* first, then sent to *Noria*.

I added an implementation of `TryFrom` for `noria::DataType` in my own fork, but we might as well have it in the master branch?