### PR TITLE
Replace `mem::replace` with assignment

### DIFF
--- a/server/dataflow/src/domain/mod.rs
+++ b/server/dataflow/src/domain/mod.rs
@@ -2607,7 +2607,7 @@ impl Domain {
             // we're told to continue replay, but nothing is being replayed
             unreachable!();
         };
-        mem::replace(&mut self.mode, was);
+        self.mode = was;
 
         if finished {
             // node is now ready, and should start accepting "real" updates

--- a/server/dataflow/src/node/process.rs
+++ b/server/dataflow/src/node/process.rs
@@ -132,7 +132,7 @@ impl Node {
 
                     match i.on_input_raw(ex, from, old_data, replay, nodes, state, log) {
                         RawProcessingResult::Regular(m) => {
-                            mem::replace(data, m.results);
+                            *data = m.results;
                             lookups = m.lookups;
                             misses = m.misses;
                         }
@@ -147,7 +147,7 @@ impl Node {
                             // we already know that m must be a ReplayPiece since only a
                             // ReplayPiece can release a ReplayPiece.
                             // NOTE: no misses or lookups here since this is a union
-                            mem::replace(data, rows);
+                            *data = rows;
                             captured = were_captured;
                             if let Packet::ReplayPiece {
                                 context:
@@ -165,7 +165,7 @@ impl Node {
                         RawProcessingResult::FullReplay(rs, last) => {
                             // we already know that m must be a (full) ReplayPiece since only a
                             // (full) ReplayPiece can release a FullReplay
-                            mem::replace(data, rs);
+                            *data = rs;
                             set_replay_last = Some(last);
                         }
                     }

--- a/server/dataflow/src/ops/union.rs
+++ b/server/dataflow/src/ops/union.rs
@@ -167,7 +167,6 @@ impl Ingredient for Union {
                 ref mut emit_l,
                 ref mut cols_l,
             } => {
-                use std::mem;
                 let mapped_emit = emit
                     .drain()
                     .map(|(mut k, v)| {
@@ -184,8 +183,8 @@ impl Ingredient for Union {
                         (k, v)
                     })
                     .collect();
-                mem::replace(emit, mapped_emit);
-                mem::replace(cols, mapped_cols);
+                *emit = mapped_emit;
+                *cols = mapped_cols;
             }
             Emit::AllFrom(ref mut p, _) => {
                 p.remap(remap);
@@ -686,7 +685,7 @@ impl Ingredient for Union {
                 };
 
                 // and swap back replay pieces
-                mem::replace(&mut self.replay_pieces, replay_pieces_tmp);
+                self.replay_pieces = replay_pieces_tmp;
 
                 // here's another bit that's a little subtle:
                 //

--- a/server/src/controller/migrate/materialization/mod.rs
+++ b/server/src/controller/migrate/materialization/mod.rs
@@ -807,7 +807,7 @@ impl Materializations {
                 let log = self.log.new(o!("node" => node.index()));
                 let log = mem::replace(&mut self.log, log);
                 self.setup(node, &mut index_on, graph, domains, workers, replies);
-                mem::replace(&mut self.log, log);
+                self.log = log;
                 index_on.clear();
             } else {
                 use dataflow::payload::InitialState;
@@ -922,7 +922,7 @@ impl Materializations {
         let log = self.log.new(o!("node" => ni.index()));
         let log = mem::replace(&mut self.log, log);
         self.setup(ni, index_on, graph, domains, workers, replies);
-        mem::replace(&mut self.log, log);
+        self.log = log;
 
         // NOTE: the state has already been marked ready by the replay completing, but we want to
         // wait for the domain to finish replay, which the ready executed by the outer commit()

--- a/server/src/controller/sql/passes/negation_removal.rs
+++ b/server/src/controller/sql/passes/negation_removal.rs
@@ -55,7 +55,7 @@ fn normalize_condition_expr(ce: &mut ConditionExpression, negate: bool) {
             } else {
                 unreachable!()
             };
-            mem::replace(ce, inner);
+            *ce = inner;
             normalize_condition_expr(ce, !negate);
         }
         ConditionExpression::Bracketed(ref mut inner) => {

--- a/server/src/controller/sql/reuse/join_order.rs
+++ b/server/src/controller/sql/reuse/join_order.rs
@@ -3,7 +3,6 @@ use super::helpers::predicate_implication::predicate_is_equivalent;
 use super::ReuseType;
 use nom_sql::ConditionTree;
 use std::collections::HashSet;
-use std::mem;
 use std::vec::Vec;
 
 #[derive(Debug, Clone)]
@@ -112,7 +111,7 @@ fn chains_to_order(chains: Vec<JoinChain>, order: &mut Vec<JoinRef>) {
     assert_eq!(new_order.len(), order.len());
 
     // replace the current order for the new order
-    mem::replace(order, new_order);
+    *order = new_order;
 }
 
 fn from_join_ref<'a>(jref: &JoinRef, qg: &'a QueryGraph) -> &'a ConditionTree {


### PR DESCRIPTION
If the result of `mem::replace` is not used, it is equivalent to assignment. This way the code is more readable and doesn't give compiler warnings.

If there is an advantage to using `mem::replace`, let me know.