### PR TITLE
Missing Tokio blocking features

### DIFF
--- a/noria/Cargo.toml
+++ b/noria/Cargo.toml
@@ -25,7 +25,7 @@ nom-sql = "0.0.11"
 serde = { version = "1.0.8", features = ["rc"] }
 serde_derive = "1.0.8"
 serde_json = "1.0.2"
-tokio = { version = "0.2.19", features = ["net", "io-util", "sync", "time"] }
+tokio = { version = "0.2.19", features = ["blocking", "rt-threaded", "net", "io-util", "sync", "time"] }
 bincode = "1.0.0"
 vec_map = { version = "0.8.0", features = ["eders"] }
 petgraph = { version = "0.5", features = ["serde-1"] }

--- a/noria/Cargo.toml
+++ b/noria/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noria"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 authors = ["The Noria developers <noria@pdos.csail.mit.edu>"]
 license = "MIT OR Apache-2.0"

--- a/noria/Cargo.toml
+++ b/noria/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noria"
-version = "0.4.2"
+version = "0.4.1"
 edition = "2018"
 authors = ["The Noria developers <noria@pdos.csail.mit.edu>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I think the current Tokio dependency is missing features.

I tried to compile a project depending on Noria, but I got the following error:
```
   Compiling noria v0.4.1 (https://github.com/mit-pdos/noria/#770509c3)
error[E0425]: cannot find function `block_in_place` in module `tokio::task`
  --> /home/jonathan/.cargo/git/checkouts/noria-8612be89bc6721f9/770509c/noria/src/channel/tcp.rs:82:26
   |
82 |             tokio::task::block_in_place(f)
   |                          ^^^^^^^^^^^^^^ not found in `tokio::task`
```

I looked at `noria/Cargo.toml`, which had the following Tokio dependency:
`tokio = { version = "0.2.19", features = ["net", "io-util", "sync", "time"] }`.

Based on [Tokio v0.2.19](https://docs.rs/tokio/0.2.19/tokio/task/fn.block_in_place.html),

![image](https://user-images.githubusercontent.com/8869660/80616258-b2abcc00-8a0e-11ea-8bad-fef5db441e63.png)

Thus, the present PR adds the two missing features: `blocking`, and `rt-threaded`. I also bump up Noria's version.