### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/noria/Cargo.toml
+++ b/noria/Cargo.toml
@@ -42,7 +42,7 @@ tokio-tower = "0.4"
 tracing = "0.1.12"
 tracing-futures = "0.2.2"
 slab = "0.4"
-pin-project = "0.4.0"
+pin-project = "0.4.17"
 futures-util = "0.3.0"
 mysql_common = "0.22"
 


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*