### PR TITLE
Fix a couple unnecessary mutable warns

### DIFF
--- a/server/dataflow/src/state/memory_state.rs
+++ b/server/dataflow/src/state/memory_state.rs
@@ -240,7 +240,7 @@ mod tests {
     #[test]
     fn memory_state_process_records() {
         let mut state = MemoryState::default();
-        let mut records: Records = vec![
+        let records: Records = vec![
             (vec![1.into(), "A".into()], true),
             (vec![2.into(), "B".into()], true),
             (vec![3.into(), "C".into()], true),

--- a/server/dataflow/src/state/persistent_state.rs
+++ b/server/dataflow/src/state/persistent_state.rs
@@ -1114,7 +1114,7 @@ mod tests {
     #[test]
     fn persistent_state_process_records() {
         let mut state = setup_persistent("persistent_state_process_records");
-        let mut records: Records = vec![
+        let records: Records = vec![
             (vec![1.into(), "A".into()], true),
             (vec![2.into(), "B".into()], true),
             (vec![3.into(), "C".into()], true),


### PR DESCRIPTION
Fix a couple "variable does not need to be mutable" warnings by dropping
a couple `mut`s