### PR TITLE
chore: use stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 language: rust
 cache: false
 rust:
-  - nightly
+  - stable
 env:
   - SETTLE_TIME=2000
 script:

--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ clients can connect. Noria also uses [Apache
 ZooKeeper](https://zookeeper.apache.org/) to announce the location of
 its servers, so ZooKeeper must be running.
 
-You (currently) need nightly Rust to build `noria-server`. This will be
-arranged for
-[automatically](https://github.com/rust-lang-nursery/rustup.rs#the-toolchain-file)
-if you're using [`rustup.rs`](https://rustup.rs/). To build
-`noria-server`, run
-
 ```console
 $ cargo build --release --bin noria-server
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
    steps:
      - template: install-rust.yml@templates
        parameters:
-         rust: nightly
+         rust: stable
          components:
            - rustfmt
      - bash: |

--- a/noria/src/lib.rs
+++ b/noria/src/lib.rs
@@ -21,8 +21,7 @@
 //!
 //! # Quickstart example
 //!
-//! If you just want to get up and running quickly, here's some code to dig into. Note that this
-//! requires a nightly release of Rust to run for the time being.
+//! If you just want to get up and running quickly, here's some code to dig into.
 //!
 //! ```no_run
 //! # use noria::*;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+stable


### PR DESCRIPTION
I couldn't find any documentation why use the nightly compiler
but since it compiles and tests pass it might be nice to use stable.