### PR TITLE
chore: upgrade evmap

### DIFF
--- a/server/dataflow/Cargo.toml
+++ b/server/dataflow/Cargo.toml
@@ -19,7 +19,7 @@ jemallocator = "0.3"
 
 [dependencies]
 bincode = "1.0.0"
-evmap = { version = "11.0.0-alpha.1", features = ["eviction"] }
+evmap = { version = "11.0.0-alpha.7", features = ["eviction"] }
 hashbag = "0.1.2"
 ahash = "0.3"
 futures-util = "0.3.0"

--- a/server/dataflow/src/backlog/multir.rs
+++ b/server/dataflow/src/backlog/multir.rs
@@ -4,9 +4,9 @@ use evmap;
 
 #[derive(Clone, Debug)]
 pub(super) enum Handle {
-    Single(evmap::ReadHandle<DataType, Vec<DataType>, i64, RandomState>),
-    Double(evmap::ReadHandle<(DataType, DataType), Vec<DataType>, i64, RandomState>),
-    Many(evmap::ReadHandle<Vec<DataType>, Vec<DataType>, i64, RandomState>),
+    Single(evmap::handles::ReadHandle<DataType, Vec<DataType>, i64, RandomState>),
+    Double(evmap::handles::ReadHandle<(DataType, DataType), Vec<DataType>, i64, RandomState>),
+    Many(evmap::handles::ReadHandle<Vec<DataType>, Vec<DataType>, i64, RandomState>),
 }
 
 impl Handle {
@@ -20,12 +20,12 @@ impl Handle {
 
     pub(super) fn meta_get_and<F, T>(&self, key: &[DataType], then: F) -> Option<(Option<T>, i64)>
     where
-        F: FnOnce(&evmap::Values<Vec<DataType>, RandomState>) -> T,
+        F: FnOnce(&evmap::refs::Values<Vec<DataType>, RandomState>) -> T,
     {
         match *self {
             Handle::Single(ref h) => {
                 assert_eq!(key.len(), 1);
-                let map = h.read()?;
+                let map = h.enter()?;
                 let v = map.get(&key[0]).map(then);
                 let m = *map.meta();
                 Some((v, m))
@@ -54,14 +54,14 @@ impl Handle {
                         1,
                     );
                     let stack_key = mem::transmute::<_, &(DataType, DataType)>(&stack_key);
-                    let map = h.read()?;
+                    let map = h.enter()?;
                     let v = map.get(&stack_key).map(then);
                     let m = *map.meta();
                     Some((v, m))
                 }
             }
             Handle::Many(ref h) => {
-                let map = h.read()?;
+                let map = h.enter()?;
                 let v = map.get(key).map(then);
                 let m = *map.meta();
                 Some((v, m))


### PR DESCRIPTION
Since in the Cargo.toml the version of evmap was "11.0.0-alpha.1" instead
of "= 11.0.0-alpha.1" for new builds the latest version is used. The
latest version of evmap is "11.0.0-alpha.7" and it is not backward
compatible. This change upgrades evmap to "11.0.0-alpha.7".