### PR TITLE
Project fix

### DIFF
--- a/server/dataflow/src/ops/project.rs
+++ b/server/dataflow/src/ops/project.rs
@@ -173,13 +173,26 @@ impl Ingredient for Project {
                                 vec![]
                             };
 
-                            new_r.extend(
-                                r.into_owned()
-                                    .into_iter()
-                                    .enumerate()
-                                    .filter(|(i, _)| emit.iter().any(|e| e == i))
-                                    .map(|(_, c)| c),
-                            );
+                            // new_r.extend(
+                            //     r.into_owned()
+                            //         .into_iter()
+                            //         .enumerate()
+                            //         .filter(|(i, _)| emit.iter().any(|e| e == i))
+                            //         .map(|(_, c)| c),
+                            // );
+
+                            {
+                                let o = r.into_owned();
+                                let l = new_r.len();
+                                debug_assert!(emit.iter().all(|e| e < &o.len()));
+                                unsafe { new_r.set_len(l + emit.len()); }
+                                for (i, c) in o.into_iter().enumerate() {
+                                    match emit.iter().enumerate().find(|(_, it)| **it == i) {
+                                        Some((idx, _)) => new_r[idx + l] = c,
+                                        None => ()
+                                    }
+                                }
+                            }
 
                             new_r.append(&mut expr);
                             if let Some(ref a) = additional {


### PR DESCRIPTION
This fixes what I think is a bug in the implementation of `query_through` in the `project` operator. The implementation assumed that columns in `emit` were monotonically increasing, but I did not read about this as an explicit invariant. As a result the implementation would not permute columns if that was requested in `emit`. The following pseudo-rust illustrates the inconsistency. 

```rs
let p = Project::new(emit=[0,2,1]); // <- permutation requested

let v = [1,2,3];
p.on_input([v]) // returns [1,3,2] <- correctly permuted
ancestor_state.insert(v);
p.query_through(..., states={key=1, states={..., ancestor_state }); // returns [1,2,3] <- not permuted
```

The new version should be as efficient as before but correctly permutes in `query_through` though I have not benchmarked it.

I added safety assertions for debug mode and added a test case.

The new implementation is less pretty and maybe less simple? So I added some comments explaining what it does.

Lmk if there are any questions or issues with the PR.